### PR TITLE
Styling rules weren't working with native Shadow DOM and more flexible styling possibilities.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0"
+    "polymer": "Polymer/polymer#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0"
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
     <head>
         <title>Simple test page for progress-bubble element</title>
         <script src="../webcomponentsjs/webcomponents.min.js"></script>
+        <script>
+            // window.Polymer = window.Polymer || {};
+            // window.Polymer.dom = 'shadow';
+        </script>
         <link rel="import" href="progress-bubble.html" />
 
         <style type="text/css">
@@ -18,7 +22,11 @@
         </style>
         <style is="custom-style">
             progress-bubble:nth-child(even) {
+                text-shadow: none;
                 --progress-bubble-stroke-color: rgba(255, 0, 0, 0.8);
+                --progress-bubble-bg-stroke-color: rgba(193, 193, 193, 0.2);
+                --progress-bubble-background: transparent;
+                --progress-bubble-reflection-display: none;
             }
         </style>
     </head>

--- a/progress-bubble.html
+++ b/progress-bubble.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <dom-module id="progress-bubble">
     <style>
@@ -8,7 +9,7 @@
             height: 100px;
             margin: 10px;
             position: relative;
-            background: radial-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.2));
+            background: var(--progress-bubble-background, radial-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.2)));
             border-radius: 50%;
             font-size: 24px;
             text-shadow: 0 2px 2px rgba(0, 0, 0, 0.8);
@@ -18,15 +19,15 @@
             opacity: 0;
             transition: opacity 150ms;
         }
-        :host.calculation-ready svg,
-        :host.calculation-ready div{
+        :host(.calculation-ready) svg,
+        :host(.calculation-ready) div{
             opacity: 1;
         }
         #reflection {
             width: 25%;
             height: 25%;
             background: url("reflection.svg") top left no-repeat;
-            display: block;
+            display: var(--progress-bubble-reflection-display, block);
             position: absolute;
             top: 14%;
             left: 15%;
@@ -35,19 +36,16 @@
         #content {
             width: 100%;
             height: 100%;
-            display: -webkit-flex;
-            display: flex;
-            -webkit-flex-direction: column;
-            flex-direction: column;
-            -webkit-align-items: center;
-            align-items: center;
-            -webkit-justify-content: center;
-            justify-content: center;
+            @apply(--layout-vertical);
+            @apply(--layout-center-center);
         }
         svg {
             position: absolute;
             top: 0;
             left: 0;
+        }
+        #bgCircle {
+            stroke: var(--progress-bubble-bg-stroke-color, rgba(255, 255, 255, 0.1));
         }
         #svgCircle {
             transition: stroke-dashoffset 150ms;
@@ -56,8 +54,8 @@
     </style>
     <template>
         <svg id="progressArc" width="100%" height="100%">
-            <circle r$="[[_radius]]" cx$="[[_cx]]" cy$="[[_cy]]" fill="transparent"
-                    stroke="rgba(255, 255, 255, 0.1)" stroke-width$="[[strokeWidth]]" />
+            <circle id="bgCircle" r$="[[_radius]]" cx$="[[_cx]]" cy$="[[_cy]]" fill="transparent"
+                    stroke-width$="[[strokeWidth]]" />
             <circle id="svgCircle" r$="[[_radius]]" cx$="[[_cx]]" cy$="[[_cy]]" fill="transparent"
                 stroke-width$="[[strokeWidth]]"
                 stroke-dasharray$="[[_dasharray]]"


### PR DESCRIPTION
Hi there,

I find you're progress-bubble awesome and want to use it in my projects.
To do this I needed more control over how the bubble looks, because the 3d like effect's don't fit in my project. So I added some css styling mixins and var's.

I also introduced `iron-flex-layout`. This maybe is point to discuss... At least it provides broader browser compatibility and is used in very many other polymer elements (so most of the time loaded anyway).

Last but not least, I fixed a little css rule styling bug that prevented the element from showing up correctly when running with native Shadow DOM.

I thought this is maybe worth an pr.

Cheers!
